### PR TITLE
Added SQLCipher support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-cipher_key.txt

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 # PyBuilder
 target/
 
+cipher_key.txt

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ sqlite>
 - [ ] Add option to search for notes using title
 - [ ] Add option to search for notes using timestamp
 - [ ] Make it pip installable
-- [ ] Encrypt the `.db` file using **Sqlcipher**
+- [x] Encrypt the `.db` file using **Sqlcipher**
 - [x] Add colorized text to the notes for improved UI
 - [ ] Add better UI using **urwid**
 

--- a/journal.py
+++ b/journal.py
@@ -17,7 +17,7 @@ import datetime
 import os
 
 from peewee import *
-
+from playhouse.sqlcipher_ext import SqlCipherDatabase
 
 try:
     input = raw_input   # for python2 compatibility
@@ -25,7 +25,9 @@ except NameError:
     pass
 
 path = os.getenv('HOME', os.path.expanduser('~')) + '/.tnote'
-db = SqliteDatabase(path + '/diary.db')
+
+with open('cipher_key.txt', 'r') as cipher_file:
+    db = SqlCipherDatabase(path + '/diary.db', passphrase=cipher_file.read())
 
 class DiaryEntry(Model):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 args==0.1.0
 clint==0.5.1
 peewee==2.8.0
-pysqlcipher3==1.0.1
+pysqlcipher3==1.0.2
 pycrypto==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 peewee==2.8.0
+pysqlcipher3==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 peewee==2.8.0
 pysqlcipher3==1.0.1
+pycrypto==2.6.1


### PR DESCRIPTION
Hey. 

I added SQLCipher support (yay).  
It was really easy to implement too so this should be pretty straightforward to merge.  

Here is some important information:  
* This requires header files for SQLCipher and I think sqlite3 as well.
I had the following packages installed: sqlite3 and libsqlcipher-dev. Though I'm pretty sure only the dev package has to be installed. But it has to be installed **before** installing pysqlcipher3 via pip.  

* The passphrase for the DB has to be at least 8 characters long (it will exit with an error if it's not the case)  

* The passphrase a DB has been created with is the only passphrase that can decipher that DB  

* The key is read from a file called *"cipher_key.txt"* which resides next to the *journal.py* file. I have added it to the .gitignore file because you definitely wouldn't want your secret keys versioned. 

I'd love to hear your feedback on this. 